### PR TITLE
Enclose the main part of the page betwen '<main></main>

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,9 +7,10 @@
 
     {% include header.html %}
 
-
+    <main>
         {{ content }}
-
+    </main>
+    
     {% include footer.html %}
       
     {% include script.html %}


### PR DESCRIPTION
This is required for the [sticky footer](http://materializecss.com/footer.html) to work and should be harmless for features that don't require it. Allow to easily distinguish in the body the main part of the page from the navbar and footer.